### PR TITLE
use 'cl-lib' macros instead of cl.el

### DIFF
--- a/docean.el
+++ b/docean.el
@@ -131,18 +131,18 @@
     (setf (url-filename urlobj) endpoint)
     (url-recreate-url urlobj)))
 
-(defun* docean-request (endpoint
-                        &key
-                        (type "GET")
-                        (params nil)
-                        (data nil)
-                        (parser 'buffer-string)
-                        (error 'docean-default-callback)
-                        (success 'docean-default-callback)
-                        (headers nil)
-                        (timeout nil)
-                        (sync nil)
-                        (status-code nil))
+(cl-defun docean-request (endpoint
+                          &key
+                          (type "GET")
+                          (params nil)
+                          (data nil)
+                          (parser 'buffer-string)
+                          (error 'docean-default-callback)
+                          (success 'docean-default-callback)
+                          (headers nil)
+                          (timeout nil)
+                          (sync nil)
+                          (status-code nil))
   "Process a request to a DigitalOcean api endpoint.
 
 All the calls to the DigitalOcean api requiere to send the key."
@@ -162,7 +162,7 @@ All the calls to the DigitalOcean api requiere to send the key."
              :status-code status-code
              :sync sync)))
 
-(defun* docean-default-callback (&key data response error-thrown &allow-other-keys)
+(cl-defun docean-default-callback (&key data response error-thrown &allow-other-keys)
   (with-current-buffer (get-buffer-create docean-debug-buffer-name)
     (erase-buffer)
     (when error-thrown
@@ -193,7 +193,7 @@ All the calls to the DigitalOcean api requiere to send the key."
   "Generate droplets table entries."
   (mapcar #'docean--generate-table-droplet-entry (docean-droplets)))
 
-(defun* docean-action-callback (&key data response error-thrown &allow-other-keys)
+(cl-defun docean-action-callback (&key data response error-thrown &allow-other-keys)
   (let ((action (cdr (assq 'action data))))
     (message "%s action started at %s with id %s"
              (cdr-safe (assq 'type action))
@@ -312,9 +312,9 @@ All the calls to the DigitalOcean api requiere to send the key."
   (add-hook 'tabulated-list-revert-hook #'docean-refetch-droplets nil t)
   (tabulated-list-init-header))
 
-(defun* docean-droplets (&key
-                         (page nil)
-                         (per-page docean-default-per-page))
+(cl-defun docean-droplets (&key
+                           (page nil)
+                           (per-page docean-default-per-page))
   "Fetch the available user droplets."
   (if docean-droplets-already-fetched
       docean-droplets
@@ -323,7 +323,7 @@ All the calls to the DigitalOcean api requiere to send the key."
            (response (docean-request "/v2/droplets"
                                      :parser 'json-read
                                      :params params
-                                     :success (function*
+                                     :success (cl-function
                                                (lambda (&key data &allow-other-keys)
                                                  (message "docean request complete")
                                                  (setq docean-droplets-already-fetched t
@@ -361,9 +361,9 @@ All the calls to the DigitalOcean api requiere to send the key."
   (add-hook 'tabulated-list-revert-hook #'docean-refetch-actions nil t)
   (tabulated-list-init-header))
 
-(defun* docean-actions (&key
-                        (page nil)
-                        (per-page docean-default-per-page))
+(cl-defun docean-actions (&key
+                          (page nil)
+                          (per-page docean-default-per-page))
   "Fetch the actions executed on the current account."
   (if docean-actions-already-fetched
       docean-actions
@@ -372,7 +372,7 @@ All the calls to the DigitalOcean api requiere to send the key."
            (response (docean-request "/v2/actions"
                                      :parser 'json-read
                                      :params params
-                                     :success (function*
+                                     :success (cl-function
                                                (lambda (&key data response &allow-other-keys)
                                                  (message "docean request complete")
                                                  (setq docean-actions-already-fetched t


### PR DESCRIPTION
Using `cl.el` macros causes byte-compile warnings as bellow.

```
Compiling file /home/syohei/tmp/docean.el/docean.el at Wed Nov 26 11:33:00 2014
Entering directory `/home/syohei/tmp/docean.el/'
docean.el:134:9:Warning: reference to free variable `docean-request'
docean.el:135:25:Warning: reference to free variable `&key'
docean.el:149:26:Warning: reference to free variable `headers'
docean.el:152:35:Warning: reference to free variable `endpoint'
docean.el:153:20:Warning: reference to free variable `type'
docean.el:157:20:Warning: reference to free variable `data'
docean.el:155:22:Warning: reference to free variable `params'
docean.el:158:14:Warning: reference to free variable `parser'
docean.el:159:23:Warning: reference to free variable `success'
docean.el:160:21:Warning: reference to free variable `error'
docean.el:161:14:Warning: reference to free variable `timeout'
docean.el:162:14:Warning: reference to free variable `status-code'
docean.el:163:14:Warning: reference to free variable `sync'
docean.el:165:9:Warning: reference to free variable `docean-default-callback'
docean.el:165:44:Warning: reference to free variable `response'
docean.el:165:53:Warning: reference to free variable `error-thrown'
docean.el:165:66:Warning: reference to free variable `&allow-other-keys'
docean.el:196:9:Warning: reference to free variable `docean-action-callback'
docean.el:315:1:Warning: Unused lexical variable `response'
docean.el:321:33:Warning: reference to free variable `page'
docean.el:322:33:Warning: reference to free variable `per-page'
docean.el:364:1:Warning: Unused lexical argument `response'
docean.el:364:1:Warning: Unused lexical variable `response'

In end of data:
docean.el:424:1:Warning: the following functions are not known to be defined: defun*,
    endpoint, type, params, data, parser, success, headers, timeout,
    sync, status-code, &key, docean-droplets, docean-request, page,
    per-page, function*, docean-actions
```
