### PR TITLE
README.md: Re-generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 *Interact with DigitalOcean from Emacs. -*- lexical-binding: t -*-*
 
 ---
-[![Travis build status](https://travis-ci.org/emacs-pe/docean.el.png?branch=master)](https://travis-ci.org/emacs-pe/docean.el)
+[![License GPLv3](https://img.shields.io/badge/license-GPL_v3-green.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
+[![Build Status](https://travis-ci.org/emacs-pe/docean.el.svg?branch=master)](https://travis-ci.org/emacs-pe/docean.el)
+[![MELPA](http://melpa.org/packages/docean-badge.svg)](http://melpa.org/#/docean)
 
 > Note: `docean.el` uses the [API v2.0](https://developers.digitalocean.com/v2/) of DigitalOcean.
 

--- a/docean.el
+++ b/docean.el
@@ -26,7 +26,6 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; [![Travis build status](https://travis-ci.org/emacs-pe/docean.el.png?branch=master)](https://travis-ci.org/emacs-pe/docean.el)
 ;;
 ;; > Note: `docean.el' uses the [API v2.0](https://developers.digitalocean.com/v2/) of DigitalOcean.
 ;;


### PR DESCRIPTION
`make-readme-markdown` has recently gained the ability to add a license badge to your `README.md` if a license can be detected.  Here's how it looks.
