### PR TITLE
Add support for authentication via netrc files

### DIFF
--- a/docean.el
+++ b/docean.el
@@ -38,10 +38,13 @@
 ;;  + Show actions performed by an account.
 ;;
 ;;; Usage:
-;; To configure your account you need generate an api key in
-;; https://cloud.digitalocean.com/settings/applications.  and to set
-;; up, you can follow any of the following options:
+;; In order to use docean.el you need to generate API key for your Digital
+;; Ocean account. Go to https://cloud.digitalocean.com/settings/applications to
+;; generate your API key. docean.el can find your API key in the following
+;; ways:
 ;;
+;;  + Add a `.authinfo.gpg` entry with the host set to "api.digitalocean.com"
+;;  and password set to the API key.
 ;;  + Add `(setq docean-oauth-token "mytoken")` to your `init.el'
 ;;  + Set the environment variable `DO_API_TOKEN'.
 ;;

--- a/docean.el
+++ b/docean.el
@@ -34,7 +34,7 @@
 ;;
 ;;; Features:
 ;;  + Show list of droplets.
-;;  + Perform [droplet actions][].
+;;  + Perform [droplet actions].
 ;;  + Show actions performed by an account.
 ;;
 ;;; Usage:
@@ -48,7 +48,7 @@
 ;; To show your droplets you can use `M-x docean-droplet-list`.
 ;;
 ;;; TODO:
-;; + [ ] Handle `meta' abd `links' in API responses.
+;; + [ ] Handle `meta' and `links' in API responses.
 ;;
 ;; [droplet actions]: https://developers.digitalocean.com/#droplet-actions
 
@@ -124,7 +124,7 @@
 (defun docean-oauth-token ()
   "Return the configured DigitalOcean token."
   (or docean-oauth-token
-      (getenv "DO_API_TOKEN")     ;; XXX: Used by dopy, and by extend ansible.
+      (getenv "DO_API_TOKEN") ; XXX: Used by dopy, and by extension Ansible.
       (let* ((docean-auth-info
               (car (auth-source-search :max 1
                                        :host "api.digitalocean.com"


### PR DESCRIPTION
Add netrc support through auth-source. We use the URL of Digital Oceann's API to find the proper entry. Because we cache the secret in the DOCEAN-OATH-TOKEN variable it is up the user
to invalidate the cache in case they update the netrc file after using DOCEAN.el for the first time.

### TODO
- [x] Document the feature in the reamde